### PR TITLE
ML Kit Library Updates

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -24,7 +24,7 @@ android {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jre7:$kotlin_version"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation 'com.android.support:appcompat-v7:27.1.1'
     implementation 'com.android.support.constraint:constraint-layout:1.1.2'
     testImplementation 'junit:junit:4.12'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -26,7 +26,7 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation 'com.android.support:appcompat-v7:27.1.1'
-    implementation 'com.android.support.constraint:constraint-layout:1.1.2'
+    implementation 'com.android.support.constraint:constraint-layout:1.1.3'
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'com.android.support.test:runner:1.0.2'
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,7 +8,7 @@ android {
     compileSdkVersion 27
     defaultConfig {
         applicationId "br.pedroso.mlkitsample"
-        minSdkVersion 15
+        minSdkVersion 16
         targetSdkVersion 27
         versionCode 1
         versionName "1.0"
@@ -31,14 +31,14 @@ dependencies {
     androidTestImplementation 'com.android.support.test:runner:1.0.2'
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
 
-    implementation ('com.google.firebase:firebase-core:16.0.1'){
+    implementation ('com.google.firebase:firebase-core:16.0.9'){
         exclude group: 'com.android.support'
     }
 
-    implementation('com.google.firebase:firebase-ml-vision:16.0.0') {
+    implementation('com.google.firebase:firebase-ml-vision:20.0.0') {
         exclude group: 'com.android.support'
     }
-    implementation ('com.google.firebase:firebase-ml-vision-image-label-model:15.0.0') {
+    implementation ('com.google.firebase:firebase-ml-vision-image-label-model:17.0.2') {
         exclude group: 'com.android.support'
     }
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -21,7 +21,7 @@
 
         <meta-data
             android:name="com.google.firebase.ml.vision.DEPENDENCIES"
-            android:value="label,face,text" />
+            android:value="label,face,text,ocr" />
 
         <activity
             android:name=".presentation.MainActivity"

--- a/app/src/main/java/br/pedroso/mlkitsample/mlkit/RxMLKit.kt
+++ b/app/src/main/java/br/pedroso/mlkitsample/mlkit/RxMLKit.kt
@@ -2,13 +2,11 @@ package br.pedroso.mlkitsample.mlkit
 
 import android.graphics.Bitmap
 import com.google.firebase.ml.vision.FirebaseVision
-import com.google.firebase.ml.vision.cloud.FirebaseVisionCloudDetectorOptions
-import com.google.firebase.ml.vision.cloud.label.FirebaseVisionCloudLabel
 import com.google.firebase.ml.vision.common.FirebaseVisionImage
 import com.google.firebase.ml.vision.face.FirebaseVisionFace
 import com.google.firebase.ml.vision.face.FirebaseVisionFaceDetectorOptions
-import com.google.firebase.ml.vision.label.FirebaseVisionLabel
-import com.google.firebase.ml.vision.label.FirebaseVisionLabelDetectorOptions
+import com.google.firebase.ml.vision.label.FirebaseVisionImageLabel
+import com.google.firebase.ml.vision.label.FirebaseVisionOnDeviceImageLabelerOptions
 import com.google.firebase.ml.vision.text.FirebaseVisionText
 import io.reactivex.Observable
 
@@ -19,11 +17,11 @@ class RxMLKit {
             val firebaseVisionImage = FirebaseVisionImage.fromBitmap(bitmap)
 
             val options = FirebaseVisionFaceDetectorOptions.Builder()
-                    .setModeType(FirebaseVisionFaceDetectorOptions.ACCURATE_MODE)
-                    .setLandmarkType(FirebaseVisionFaceDetectorOptions.ALL_LANDMARKS)
-                    .setClassificationType(FirebaseVisionFaceDetectorOptions.ALL_CLASSIFICATIONS)
+                    .setPerformanceMode(FirebaseVisionFaceDetectorOptions.ACCURATE)
+                    .setLandmarkMode(FirebaseVisionFaceDetectorOptions.ALL_LANDMARKS)
+                    .setClassificationMode(FirebaseVisionFaceDetectorOptions.ALL_CLASSIFICATIONS)
                     .setMinFaceSize(0.15f)
-                    .setTrackingEnabled(true)
+                    .enableTracking()
                     .build()
 
             val detector = FirebaseVision.getInstance()
@@ -44,9 +42,9 @@ class RxMLKit {
 
             val firebaseVisionImage = FirebaseVisionImage.fromBitmap(bitmap)
 
-            val detector = FirebaseVision.getInstance().visionTextDetector
+            val detector = FirebaseVision.getInstance().onDeviceTextRecognizer
 
-            detector.detectInImage(firebaseVisionImage)
+            detector.processImage(firebaseVisionImage)
                     .addOnSuccessListener {
                         observableEmitter.onNext(it)
                         observableEmitter.onComplete()
@@ -56,19 +54,19 @@ class RxMLKit {
                     }
         }
 
-        fun labelImageLocal(bitmap: Bitmap) = Observable.create<List<FirebaseVisionLabel>> {
+        fun labelImageLocal(bitmap: Bitmap) = Observable.create<List<FirebaseVisionImageLabel>> {
             val observableEmitter = it
 
             val firebaseVisionImage = FirebaseVisionImage.fromBitmap(bitmap)
 
-            val options = FirebaseVisionLabelDetectorOptions.Builder()
+            val options = FirebaseVisionOnDeviceImageLabelerOptions.Builder()
                     .setConfidenceThreshold(0.8f)
                     .build()
 
             val detector = FirebaseVision.getInstance()
-                    .getVisionLabelDetector(options)
+                    .getOnDeviceImageLabeler(options)
 
-            detector.detectInImage(firebaseVisionImage)
+            detector.processImage(firebaseVisionImage)
                     .addOnSuccessListener {
                         observableEmitter.onNext(it)
                         observableEmitter.onComplete()
@@ -78,20 +76,13 @@ class RxMLKit {
                     }
         }
 
-        fun labelImageRemote(bitmap: Bitmap) = Observable.create<List<FirebaseVisionCloudLabel>> {
+        fun labelImageRemote(bitmap: Bitmap) = Observable.create<List<FirebaseVisionImageLabel>> {
             val observableEmitter = it
 
             val firebaseVisionImage = FirebaseVisionImage.fromBitmap(bitmap)
+            val detector = FirebaseVision.getInstance().cloudImageLabeler
 
-            val options = FirebaseVisionCloudDetectorOptions.Builder()
-                    .setModelType(FirebaseVisionCloudDetectorOptions.LATEST_MODEL)
-                    .setMaxResults(15)
-                    .build()
-
-            val detector = FirebaseVision.getInstance()
-                    .getVisionCloudLabelDetector(options)
-
-            detector.detectInImage(firebaseVisionImage)
+            detector.processImage(firebaseVisionImage)
                     .addOnSuccessListener {
                         observableEmitter.onNext(it)
                         observableEmitter.onComplete()

--- a/app/src/main/java/br/pedroso/mlkitsample/presentation/mappers/FaceDetectionResultMapper.kt
+++ b/app/src/main/java/br/pedroso/mlkitsample/presentation/mappers/FaceDetectionResultMapper.kt
@@ -70,15 +70,15 @@ class FaceDetectionResultMapper {
                 }
 
         private val landmarksToDraw = arrayListOf(
-                FirebaseVisionFaceLandmark.BOTTOM_MOUTH,
+                FirebaseVisionFaceLandmark.MOUTH_BOTTOM,
                 FirebaseVisionFaceLandmark.LEFT_CHEEK,
                 FirebaseVisionFaceLandmark.LEFT_EAR,
                 FirebaseVisionFaceLandmark.LEFT_EYE,
-                FirebaseVisionFaceLandmark.LEFT_MOUTH,
+                FirebaseVisionFaceLandmark.MOUTH_LEFT,
                 FirebaseVisionFaceLandmark.NOSE_BASE,
                 FirebaseVisionFaceLandmark.RIGHT_CHEEK,
                 FirebaseVisionFaceLandmark.RIGHT_EAR,
                 FirebaseVisionFaceLandmark.RIGHT_EYE,
-                FirebaseVisionFaceLandmark.RIGHT_MOUTH)
+                FirebaseVisionFaceLandmark.MOUTH_RIGHT)
     }
 }

--- a/app/src/main/java/br/pedroso/mlkitsample/presentation/mappers/LabelLocalResultMapper.kt
+++ b/app/src/main/java/br/pedroso/mlkitsample/presentation/mappers/LabelLocalResultMapper.kt
@@ -1,25 +1,21 @@
 package br.pedroso.mlkitsample.presentation.mappers
 
 import android.graphics.Bitmap
-import android.graphics.Canvas
-import android.graphics.Color
-import android.graphics.Paint
-import android.text.TextUtils
 import br.pedroso.mlkitsample.presentation.ImageProcessingResult
-import com.google.firebase.ml.vision.label.FirebaseVisionLabel
+import com.google.firebase.ml.vision.label.FirebaseVisionImageLabel
 
 class LabelLocalResultMapper {
     companion object {
-        fun mapResult(originalImage: Bitmap, labels: List<FirebaseVisionLabel>): ImageProcessingResult {
-            val resultText: String = createResultText(labels)
+        fun mapResult(
+                originalImage: Bitmap,
+                labels: List<FirebaseVisionImageLabel>
+        ) = ImageProcessingResult(originalImage, createResultText(labels))
 
-            return ImageProcessingResult(originalImage, resultText)
-        }
-
-        private fun createResultText(labels: List<FirebaseVisionLabel>) = if (labels.isNotEmpty()) {
-            labels.map { it.label }.joinToString()
-        } else {
-            "No labels available!"
-        }
+        private fun createResultText(labels: List<FirebaseVisionImageLabel>) =
+                if (labels.isNotEmpty()) {
+                    labels.joinToString { it.text }
+                } else {
+                    "No labels available!"
+                }
     }
 }

--- a/app/src/main/java/br/pedroso/mlkitsample/presentation/mappers/LabelRemoteResultMapper.kt
+++ b/app/src/main/java/br/pedroso/mlkitsample/presentation/mappers/LabelRemoteResultMapper.kt
@@ -2,18 +2,18 @@ package br.pedroso.mlkitsample.presentation.mappers
 
 import android.graphics.Bitmap
 import br.pedroso.mlkitsample.presentation.ImageProcessingResult
-import com.google.firebase.ml.vision.cloud.label.FirebaseVisionCloudLabel
+import com.google.firebase.ml.vision.label.FirebaseVisionImageLabel
 
 class LabelRemoteResultMapper {
     companion object {
-        fun mapResult(originalImage: Bitmap, labels: List<FirebaseVisionCloudLabel>): ImageProcessingResult {
+        fun mapResult(originalImage: Bitmap, labels: List<FirebaseVisionImageLabel>): ImageProcessingResult {
             val resultText: String = createResultText(labels)
 
             return ImageProcessingResult(originalImage, resultText)
         }
 
-        private fun createResultText(labels: List<FirebaseVisionCloudLabel>) = if (labels.isNotEmpty()) {
-            labels.map { it.label }.joinToString()
+        private fun createResultText(labels: List<FirebaseVisionImageLabel>) = if (labels.isNotEmpty()) {
+            labels.map { it.text }.joinToString()
         } else {
             "No labels available!"
         }

--- a/app/src/main/java/br/pedroso/mlkitsample/presentation/mappers/TextDetectionResultMapper.kt
+++ b/app/src/main/java/br/pedroso/mlkitsample/presentation/mappers/TextDetectionResultMapper.kt
@@ -18,7 +18,10 @@ class TextDetectionResultMapper {
         }
 
         private fun createResultText(detectedText: FirebaseVisionText): String {
-            val blocksAmount = detectedText.blocks.flatMap { it.lines }.flatMap { it.elements }.size
+            val blocksAmount = detectedText.textBlocks
+                    .flatMap { it.lines }
+                    .flatMap { it.elements }
+                    .size
 
             return "Elements detected: $blocksAmount"
         }
@@ -29,7 +32,7 @@ class TextDetectionResultMapper {
             val canvas = Canvas(annotatedBitmap)
             canvas.drawBitmap(originalImage, 0f, 0f, null)
 
-            detectedText.blocks.forEach {
+            detectedText.textBlocks.forEach {
                 canvas.drawRect(it.boundingBox, textBoundingBoxPaint)
 
                 it.lines.flatMap { it.elements }.forEach {

--- a/app/src/main/java/br/pedroso/mlkitsample/presentation/mappers/TextDetectionResultMapper.kt
+++ b/app/src/main/java/br/pedroso/mlkitsample/presentation/mappers/TextDetectionResultMapper.kt
@@ -4,6 +4,7 @@ import android.graphics.Bitmap
 import android.graphics.Canvas
 import android.graphics.Color
 import android.graphics.Paint
+import android.graphics.RectF
 import br.pedroso.mlkitsample.presentation.ImageProcessingResult
 import com.google.firebase.ml.vision.text.FirebaseVisionText
 
@@ -36,7 +37,9 @@ class TextDetectionResultMapper {
                 canvas.drawRect(it.boundingBox, textBoundingBoxPaint)
 
                 it.lines.flatMap { it.elements }.forEach {
-                    canvas.drawRect(it.boundingBox, textBoundingBoxPaint)
+                    val rect = RectF(it.boundingBox)
+                    canvas.drawRect(rect, textBoundingBoxPaint)
+                    canvas.drawText(it.text, rect.left, rect.bottom, textPaint)
                 }
             }
 
@@ -48,6 +51,12 @@ class TextDetectionResultMapper {
                     strokeWidth = 5f
                     color = Color.MAGENTA
                     style = Paint.Style.STROKE
+                }
+
+        private val textPaint =
+                Paint().apply {
+                    color = Color.MAGENTA
+                    textSize = 50.0f
                 }
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,7 +1,7 @@
 <resources>
     <string name="app_name">MLKit Sample</string>
     <string name="detect_faces">Detect Faces</string>
-    <string name="detect_text">Detect Text</string>
+    <string name="detect_text">Detect Text Local</string>
     <string name="label_local">Label Local</string>
     <string name="label_remote">Label Remote</string>
     <string name="generic_error">Failed to process image.</string>

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:3.4.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        classpath 'com.google.gms:google-services:4.0.0'
+        classpath 'com.google.gms:google-services:4.2.0'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }

--- a/build.gradle
+++ b/build.gradle
@@ -1,13 +1,13 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.2.30'
+    ext.kotlin_version = '1.3.10'
     repositories {
         google()
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.3'
+        classpath 'com.android.tools.build:gradle:3.4.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath 'com.google.gms:google-services:4.0.0'
         // NOTE: Do not place your application dependencies here; they belong

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Jul 14 11:49:57 BRT 2018
+#Thu May 16 23:15:58 BST 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip


### PR DESCRIPTION
Mainly proposes the updating of ML Kit Library, additionally updates a couple of the Android dependencies.

Updating the ML Kit library was simple but, as the API changed a bit, it demanded a couple of code changes. It was also necessary to specify the usage of local text processing model, but possibly we can implement the cloud based one.

As a suggestion and with the unification of `FirebaseVisionLabel` and `FirebaseVisionCloudLabel` into `FirebaseVisionImageLabel` we can possibly keep only one mapper (could be done here or on a next PR).

Finally as a small improvement the recognised text was added to the overlay on the processed image with the recognised bounding rects.
